### PR TITLE
lock objects for update during worker startup

### DIFF
--- a/huey_monitor/tasks.py
+++ b/huey_monitor/tasks.py
@@ -108,7 +108,7 @@ def startup_handler():
     logger.debug("startup handler called")
 
     with transaction.atomic():
-        qs = TaskModel.objects.filter(state__signal_name="executing")
+        qs = TaskModel.objects.select_for_update(skip_locked=True).filter(state__signal_name="executing")
         for task_model_instance in qs:
             logger.warning(
                 'Mark "executing" task %s to "unknown"', task_model_instance.pk


### PR DESCRIPTION
We ran into issue with deadlocks between multiple huey workers upon startup.
```
OperationalError('deadlock detected\nDETAIL:  Process 23206 waits for ShareLock on transaction 78323963; blocked by process 23207.\nProcess 23207 waits for ShareLock on transaction 78323964; blocked by process 23206.\nHINT:  See server log for query details.\nCONTEXT:  while updating tuple (287,14) in relation "huey_monitor_taskmodel"\n')
```

This happened during huey worker startup as `startup_hook()` -> `update_task_instance()`. Apparently as we had other workers some tasks which were marked "executing" were updated by this worker as well as some tasks. This happened because we read set of tasks to update without locking and other processes freely lock rows we are aiming to update. 

